### PR TITLE
Fixed button icons for zen-v1.14.6b

### DIFF
--- a/chrome.css
+++ b/chrome.css
@@ -15,18 +15,17 @@
 
 .titlebar-min {
     background-color: hsl(130, 50%, 40%) !important;
+    content: none !important;
 }
 
 .titlebar-max, .titlebar-restore {
     background-color: hsl(60, 50%, 50%) !important;
+    content: none !important;
 }
 
 .titlebar-close {
     background-color: hsl(0, 50%, 50%) !important;
-}
-
-.titlebar-button > image {
-    visibility: collapse !important;
+    content: none !important;
 }
 
 @media (-moz-bool-pref: "theme.zen-minimal-exit-menu.enable-macos-identic") {


### PR DESCRIPTION
In the latest v1.14.6b update, the   (min, max, close) buttons have now actual characters instead of images.
So removed the `.titlebar-button > image`, instead added ` content: none !important` for the three buttons.